### PR TITLE
bug solved on mpc_run_solver

### DIFF
--- a/mpc_run_solver.py
+++ b/mpc_run_solver.py
@@ -30,7 +30,7 @@ def run(wdir, command, script, np, do_pause):
 			subprocess.Popen(['gnome-terminal', '--', './{}'.format(runner_name)], cwd=wdir)
 			# launch monitor
 			monitor_name = '{}.sh'.format(monitor_base_name)
-			if monitor_name in getfiles(wdir):
+			if monitor_name in getfiles(os.getcwd()):
 				subprocess.Popen(['sh', './{}'.format(monitor_name)], cwd=wdir)
 			
 		else:
@@ -54,7 +54,7 @@ def run(wdir, command, script, np, do_pause):
 			subprocess.Popen(runner_name)
 			# launch monitor
 			monitor_name = '{}.bat'.format(monitor_base_name)
-			if monitor_name in getfiles(wdir):
+			if monitor_name in getfiles(os.getcwd()):
 				subprocess.Popen(monitor_name, creationflags=0x08000000)
 		finally:
 			os.chdir(current_wdir)


### PR DESCRIPTION
Solved a bug that caused errors when using monitors with parametric analyses from python.
The folder for checking if the file monitor exists was changed (line 53), so that line 57 look for the folder "wdir" inside the folder that was already set to "wdir".

Tested both with parametric analyses from python and running single models from STKO.