### PR TITLE
Change way of computing confined parameters

### DIFF
--- a/opensees/physical_properties/materials/uniaxial/Concrete01.py
+++ b/opensees/physical_properties/materials/uniaxial/Concrete01.py
@@ -147,6 +147,9 @@ def getMaterialProperties(xobj):
 def getParamsConfinedVersion(xobj,fcc,epscc0,epsccu,fccu):
 	# This function returns the paramters of the materials
 	#	in confined version, given the main parameters
+
+	# Estimate fracture energy
+	gc = 0.5 * epscc0 * fcc + 0.5 * (fcc + fccu) * (epsccu - epscc0)
 	
 	# get Parameters of unconfined version
 	fc = __get_xobj_attribute(xobj, 'fpc').quantityScalar.value
@@ -159,4 +162,12 @@ def getParamsConfinedVersion(xobj,fcc,epscc0,epsccu,fccu):
 	epscc0 = 2 * fcc / Ec
 	# epscc0 = (epscc0 + (2 * fcc / Ec))/2
 	
+	# # Option 1: pass through point fccu, epsccu but tend to the same residual as unconfined
+	# epsccu = epscc0 + (fcu - fcc) * (epsccu - epscc0) / (fccu - fcc)
+	# fccu = fcu
+	
+	# Option 2: proposal energy equivalence
+	# Increase residual stress by same ammount of peak stress TODO: check if something better can be done
+	fccu = fcu * fcc / fc
+	epsccu = (2 * gc - fcc * epscc0)/(fcc + fccu) + epscc0
 	return (fcc, epscc0, fccu, epsccu)

--- a/opensees/physical_properties/materials/uniaxial/Concrete01WithSITC.py
+++ b/opensees/physical_properties/materials/uniaxial/Concrete01WithSITC.py
@@ -193,6 +193,9 @@ def getMaterialProperties(xobj):
 def getParamsConfinedVersion(xobj,fcc,epscc0,epsccu,fccu):
 	# This function returns the paramters of the materials
 	#	in confined version, given the main parameters
+
+	# Estimate fracture energy
+	gc = 0.5 * epscc0 * fcc + 0.5 * (fcc + fccu) * (epsccu - epscc0)
 	
 	# get Parameters of unconfined version
 	fc = __get_xobj_attribute(xobj, 'fpc').quantityScalar.value
@@ -204,6 +207,15 @@ def getParamsConfinedVersion(xobj,fcc,epscc0,epsccu,fccu):
 	# Mantain E and compute a different epsc0
 	epscc0 = 2 * fcc / Ec
 	# epscc0 = (epscc0 + (2 * fcc / Ec))/2
+	
+	# # Option 1: pass through point fccu, epsccu but tend to the same residual as unconfined
+	# epsccu = epscc0 + (fcu - fcc) * (epsccu - epscc0) / (fccu - fcc)
+	# fccu = fcu
+	
+	# Option 2: proposal energy equivalence
+	# Increase residual stress by same ammount of peak stress TODO: check if something better can be done
+	fccu = fcu * fcc / fc
+	epsccu = (2 * gc - fcc * epscc0)/(fcc + fccu) + epscc0
 	
 	params = (fcc, epscc0, fccu, epsccu)
 	

--- a/opensees/physical_properties/materials/uniaxial/Concrete02.py
+++ b/opensees/physical_properties/materials/uniaxial/Concrete02.py
@@ -199,6 +199,9 @@ def getMaterialProperties(xobj):
 def getParamsConfinedVersion(xobj,fcc,epscc0,epsccu,fccu):
 	# This function returns the paramters of the materials
 	#	in confined version, given the main parameters
+
+	# Estimate fracture energy
+	gc = 0.5 * epscc0 * fcc + 0.5 * (fcc + fccu) * (epsccu - epscc0)
 	
 	# get Parameters of unconfined version
 	fc = __get_xobj_attribute(xobj, 'fpc').quantityScalar.value
@@ -213,5 +216,14 @@ def getParamsConfinedVersion(xobj,fcc,epscc0,epsccu,fccu):
 	# Mantain E and compute a different epsc0
 	epscc0 = 2 * fcc / Ec
 	# epscc0 = (epscc0 + (2 * fcc / Ec))/2
+	
+	# # Option 1: pass through point fccu, epsccu but tend to the same residual as unconfined
+	# epsccu = epscc0 + (fcu - fcc) * (epsccu - epscc0) / (fccu - fcc)
+	# fccu = fcu
+	
+	# Option 2: proposal energy equivalence
+	# Increase residual stress by same ammount of peak stress TODO: check if something better can be done
+	fccu = fcu * fcc / fc
+	epsccu = (2 * gc - fcc * epscc0)/(fcc + fccu) + epscc0
 	
 	return (fcc, epscc0, fccu, epsccu, lambd, ft, Ets)

--- a/opensees/physical_properties/materials/uniaxial/Concrete06.py
+++ b/opensees/physical_properties/materials/uniaxial/Concrete06.py
@@ -266,7 +266,7 @@ def getParamsConfinedVersion(xobj,fcc,epscc0,epsccu,fccu):
 			#solution is between C and B
 			yA, nA = yC, nC
 		else:
-			#solution is between A and Calculate
+			#solution is between A and C
 			yB, nB = yC, nC
 		it += 1
 	# print('Computed n = ', nC)


### PR DESCRIPTION
@MassimoPetracca , this PR proposed a change in the way of computing confined parameters for Concrete01, Concrete01WithSITC and Concrete02. 
Now the confined version drops to a residual equal to K*fcu (where K is the increasing of peak strength due to confinement). The slope of softening is computed in order to have an energy equivalence respect to Mander model that assumes failure corresponding to failure of the first hoop.